### PR TITLE
Remove ppt/pptx extension before adding .pdf

### DIFF
--- a/batch_ppt_to_pdf.py
+++ b/batch_ppt_to_pdf.py
@@ -18,7 +18,8 @@ def convert_files_in_folder(powerpoint, folder):
     pptfiles = [f for f in files if f.endswith((".ppt", ".pptx"))]
     for pptfile in pptfiles:
         fullpath = os.path.join(folder, pptfile)
-        ppt_to_pdf(powerpoint, fullpath, fullpath)
+        output = os.path.splitext(fullpath)[0] + ".pdf"
+        ppt_to_pdf(powerpoint, fullpath, output)
 
 if __name__ == "__main__":
     powerpoint = init_powerpoint()


### PR DESCRIPTION
Use os.path.splitext() to strip the original extension so the output file becomes 'example.pdf' instead of 'example.pptx.pdf'.